### PR TITLE
Exclude .LocalBeach from initial copy of files

### DIFF
--- a/root-files/opt/flownative/lib/sync.sh
+++ b/root-files/opt/flownative/lib/sync.sh
@@ -94,6 +94,7 @@ sync_copy() {
     rsync -Ca \
         --chown=1000:0 \
         --exclude .Docker/ \
+        --exclude .LocalBeach/ \
         --exclude .DS_Store \
         --exclude .bundle/ \
         --exclude .git/ \


### PR DESCRIPTION
Files in there are often used through mounts in other containers,
copying them is not needed and may even lead to issues (e.g. when
files disappear during the intial copy because of external changes.)